### PR TITLE
Update to support autoextend of sports recordings.

### DIFF
--- a/base.xml
+++ b/base.xml
@@ -691,6 +691,9 @@
     </spinbox>
 
     <!-- Base definition of a wide spinbox (room for strings) -->
+    <spinbox name="basemedwidespinbox" from="basespinbox">
+        <area>0,0,346,44</area>
+    </spinbox>
     <spinbox name="basewidespinbox" from="basespinbox">
         <area>0,0,696,44</area>
     </spinbox>

--- a/schedule-ui.xml
+++ b/schedule-ui.xml
@@ -1764,7 +1764,7 @@
             <helptext></helptext>
         </buttonlist>
 
-        <spinbox name="startoffset" from="basewidespinbox">
+        <spinbox name="startoffset" from="basemedwidespinbox">
             <position>250,400</position>
             <template type="negative">Start recording %n minute(s) late</template>
             <template type="zero">Start recording on time</template>
@@ -1772,8 +1772,8 @@
             <helptext></helptext>
         </spinbox>
 
-        <spinbox name="endoffset" from="basewidespinbox">
-            <position>250,444</position>
+        <spinbox name="endoffset" from="basemedwidespinbox">
+            <position>600,400</position>
             <template type="negative">End recording %n minute(s) early</template>
             <template type="zero">End recording on time</template>
             <template type="positive">End recording %n minute(s) late</template>
@@ -1781,11 +1781,16 @@
         </spinbox>
 
         <buttonlist name="dupmethod" from="basewideselector">
-            <position>250,490</position>
+            <position>250,444</position>
             <helptext></helptext>
         </buttonlist>
 
         <buttonlist name="dupscope" from="basewideselector">
+            <position>250,490</position>
+            <helptext></helptext>
+        </buttonlist>
+
+        <buttonlist name="autoextend" from="basewideselector">
             <position>250,534</position>
             <helptext></helptext>
         </buttonlist>

--- a/themeinfo.xml
+++ b/themeinfo.xml
@@ -34,7 +34,7 @@
         <major>1</major>
 
         <!-- Minor version changes are backwards compatible -->
-        <minor>12</minor>
+        <minor>13</minor>
     </version>
 
     <!-- Theme Details (Required) -->


### PR DESCRIPTION
Extending sports recordings can be done with one of two services. This adds an extra spinbox to the "Schedule Options" page of the recordings editor to allow you to choose the service.